### PR TITLE
Add missing include needed for transform function

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <algorithm>
 #include <unistd.h>
 #include <dirent.h>
 #include <stdlib.h>


### PR DESCRIPTION
Hello,

Yours was the simplest working program to extract .mpq files that I found. When I executed make there was a compilation error saying transform is not declared in this scope. Including the algorithm library fixed it for me, but I am not sure why it happened in the first place (my best guess is changes in the libraries themselves). Obviously it has been a long time since you last touched this but I thought you might want to keep it in working condition. Thanks again for the great software.